### PR TITLE
auc-162 feat : jwt 토큰을 가져와서 파일 업로드시 회원번호 DB 저장 추가

### DIFF
--- a/src/main/java/kr/toyauction/domain/image/controller/ImageController.java
+++ b/src/main/java/kr/toyauction/domain/image/controller/ImageController.java
@@ -7,10 +7,12 @@ import kr.toyauction.domain.image.service.ImageService;
 import kr.toyauction.domain.image.validation.ImageValidator;
 import kr.toyauction.global.dto.SuccessResponse;
 import kr.toyauction.global.dto.SuccessResponseHelper;
+import kr.toyauction.global.dto.VerifyMember;
 import kr.toyauction.global.property.Url;
 import kr.toyauction.infra.property.IntraProperty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
@@ -33,8 +35,8 @@ public class ImageController {
 
 
 	@PostMapping(value = Url.IMAGE)
-	public SuccessResponse<ImagePostResponse> postFile(@Validated ImagePostRequest request) {
-		ImageEntity imageEntity = imageService.save(request);
+	public SuccessResponse<ImagePostResponse> postFile(@Validated ImagePostRequest request, VerifyMember verifyMember) {
+		ImageEntity imageEntity = imageService.save(request, verifyMember.getId());
 		return SuccessResponseHelper.success(new ImagePostResponse(imageEntity, intraProperty.getAwsS3Host()));
 	}
 }

--- a/src/main/java/kr/toyauction/domain/image/service/ImageService.java
+++ b/src/main/java/kr/toyauction/domain/image/service/ImageService.java
@@ -27,13 +27,13 @@ public class ImageService {
 	private final IntraAwsS3Client intraAwsS3Client;
 
 	@Transactional
-	public ImageEntity save(final ImagePostRequest request) {
+	public ImageEntity save(final ImagePostRequest request, final Long memberId) {
 
 		String prefixKey = CommonUtils.generateS3PrefixKey();
 		String randomFilename = CommonUtils.generateRandomFilename(Objects.requireNonNull(request.getImage().getOriginalFilename()));
 
 		ImageEntity imageEntity = ImageEntity.builder()
-				.memberId(0L) // TODO
+				.memberId(memberId) // TODO
 				.path(prefixKey + randomFilename)
 				.build();
 		imageEntity.validation();

--- a/src/main/java/kr/toyauction/global/dto/VerifyMember.java
+++ b/src/main/java/kr/toyauction/global/dto/VerifyMember.java
@@ -1,0 +1,58 @@
+package kr.toyauction.global.dto;
+
+import kr.toyauction.global.token.JwtEnum;
+import lombok.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyMember implements Authentication {
+
+	private Collection<? extends GrantedAuthority> authorities;
+	private Object principal;
+	private Object credentials;
+	private Object detail;
+	private Long id;
+	private String name;
+	private String platform;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return this.authorities;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return this.credentials;
+	}
+
+	@Override
+	public Object getDetails() {
+		return this.detail;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return this.principal;
+	}
+
+	@Override
+	public boolean isAuthenticated() {
+		return true;
+	}
+
+	@Override
+	public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+}


### PR DESCRIPTION
## 💁‍♂️ PR 내용

jwt 헤더 첨부시, 회원정보를 가져올 수 없는 문제를 해결 했습니다. 파일 등록시 등록한 회원번호를 DB에 저장할 수 있도록 추가 되었습니다. 

## 🙏 작업

- JWT 토큰 획득시 회원정보로 변환하는 기능 임시로 처리
- 파일 등록시 등록한 회원번호 DB 에 저장하는 부분 추가 

## 🙈 PR 참고 사항

jwt 헤더에 추가할 경우 회원정보를 가져오는 부분은 현재 만들어진 코드를 최대한 수정하지 않는 방향으로 임시로 처리한것이며 
절대 정석적인 방법은 아니므로 절대 따라해서는 안됩니다. 추후 시간날때 리팩토링 진행이 필요 합니다.
