### PR TITLE
auc-99 알람 확인 비지니스 로직 구현

### DIFF
--- a/src/main/java/kr/toyauction/domain/alert/controller/AlertController.java
+++ b/src/main/java/kr/toyauction/domain/alert/controller/AlertController.java
@@ -33,7 +33,7 @@ public class AlertController {
 
     @PostMapping(Url.ALERT +"/{alertId}")
     @PreAuthorize("hasRole('USER')")
-    public SuccessResponse<String> getAlert(@PathVariable final Long alertId){
-        return SuccessResponseHelper.success(alertService.getAlert(alertId));
+    public SuccessResponse<String> alertCheck(@PathVariable final Long alertId){
+        return SuccessResponseHelper.success(alertService.alertCheck(alertId));
     }
 }

--- a/src/main/java/kr/toyauction/domain/alert/controller/AlertController.java
+++ b/src/main/java/kr/toyauction/domain/alert/controller/AlertController.java
@@ -32,9 +32,7 @@ public class AlertController {
     }
 
     @PostMapping(Url.ALERT +"/{alertId}")
-    public String getAlert(@PathVariable final Long alertId){
-        return "{\n" +
-                "\t\"success\" : true\n" +
-                "}";
+    public SuccessResponse<String> getAlert(@PathVariable final Long alertId){
+        return SuccessResponseHelper.success(alertService.getAlert(alertId));
     }
 }

--- a/src/main/java/kr/toyauction/domain/alert/controller/AlertController.java
+++ b/src/main/java/kr/toyauction/domain/alert/controller/AlertController.java
@@ -32,6 +32,7 @@ public class AlertController {
     }
 
     @PostMapping(Url.ALERT +"/{alertId}")
+    @PreAuthorize("hasRole('USER')")
     public SuccessResponse<String> getAlert(@PathVariable final Long alertId){
         return SuccessResponseHelper.success(alertService.getAlert(alertId));
     }

--- a/src/main/java/kr/toyauction/domain/alert/entity/Alert.java
+++ b/src/main/java/kr/toyauction/domain/alert/entity/Alert.java
@@ -62,4 +62,8 @@ public class Alert extends BaseEntity implements EntitySupport {
 			throw new DomainValidationException();
 		}
 	}
+
+	public void setAlertRead(boolean alertRead) {
+		this.alertRead = alertRead;
+	}
 }

--- a/src/main/java/kr/toyauction/domain/alert/service/AlertService.java
+++ b/src/main/java/kr/toyauction/domain/alert/service/AlertService.java
@@ -46,7 +46,7 @@ public class AlertService {
 	}
 
 	@Transactional
-	public String getAlert(Long alertId){
+	public String alertCheck(Long alertId){
 		Alert alert = alertRepository.findById(alertId)
 				.orElseThrow(DomainNotFoundException::new);
 		alert.setAlertRead(true);

--- a/src/main/java/kr/toyauction/domain/alert/service/AlertService.java
+++ b/src/main/java/kr/toyauction/domain/alert/service/AlertService.java
@@ -4,6 +4,7 @@ import kr.toyauction.domain.alert.dto.AlertGetResponse;
 import kr.toyauction.domain.alert.dto.AlertPostRequest;
 import kr.toyauction.domain.alert.entity.Alert;
 import kr.toyauction.domain.alert.repository.AlertRepository;
+import kr.toyauction.global.exception.DomainNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
@@ -42,5 +43,13 @@ public class AlertService {
 
 	public Page<AlertGetResponse> getAlerts(Long memberId, Pageable pageable){
 		return alertRepository.findByMemberId(memberId,pageable).map(AlertGetResponse::new);
+	}
+
+	@Transactional
+	public String getAlert(Long alertId){
+		Alert alert = alertRepository.findById(alertId)
+				.orElseThrow(DomainNotFoundException::new);
+		alert.setAlertRead(true);
+		return null;
 	}
 }

--- a/src/test/java/kr/toyauction/domain/alert/controller/AlertControllerTest.java
+++ b/src/test/java/kr/toyauction/domain/alert/controller/AlertControllerTest.java
@@ -149,6 +149,7 @@ class AlertControllerTest {
 
 		Long alertId = 125L;
 		mockMvc.perform(post(Url.ALERT + "/{alertId}", alertId)
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + TestProperty.TEST_ACCESS_TOKEN)
 						.contentType(MediaType.APPLICATION_JSON_VALUE))
 				.andDo(print())
 				.andExpect(status().isOk())

--- a/src/test/java/kr/toyauction/domain/alert/controller/AlertControllerTest.java
+++ b/src/test/java/kr/toyauction/domain/alert/controller/AlertControllerTest.java
@@ -166,4 +166,15 @@ class AlertControllerTest {
 				));
 	}
 
+	@Test
+	@DisplayName("fail : 알림 확인 - 토큰이 없을 때")
+	void postAlertNullToken() throws Exception {
+
+		Long alertId = 125L;
+		ResultActions resultActions = mockMvc.perform(post(Url.ALERT + "/{alertId}", alertId)
+						.contentType(MediaType.APPLICATION_JSON_VALUE));
+
+		resultActions.andExpect(status().isUnauthorized());
+	}
+
 }

--- a/src/test/java/kr/toyauction/domain/alert/service/AlertServiceTest.java
+++ b/src/test/java/kr/toyauction/domain/alert/service/AlertServiceTest.java
@@ -5,6 +5,7 @@ import kr.toyauction.domain.alert.dto.AlertPostRequest;
 import kr.toyauction.domain.alert.entity.Alert;
 import kr.toyauction.domain.alert.repository.AlertRepository;
 import kr.toyauction.global.entity.AlertCode;
+import kr.toyauction.global.exception.DomainNotFoundException;
 import kr.toyauction.global.exception.DomainValidationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -141,7 +142,7 @@ public class AlertServiceTest {
 
     @Test
     @DisplayName("success : 알람목록 조회")
-    void getAlert(){
+    void getAlerts(){
         // given
         Alert alert = Alert.builder()
                 .id(1L)
@@ -167,5 +168,49 @@ public class AlertServiceTest {
         assertEquals(alert.getUrl(),result.getContent().get(0).getUrl());
         assertEquals(alert.isAlertRead(),result.getContent().get(0).isAlertRead());
         assertEquals(alert.getEndDatetime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), result.getContent().get(0).getEndDateTime());
+    }
+
+    @Test
+    @DisplayName("success : 알람목록 확인")
+    void alertCheck(){
+        // given
+        Alert alert = Alert.builder()
+                .id(1L)
+                .memberId(1L)
+                .title("제목")
+                .contents("내용")
+                .code(AlertCode.AC0007)
+                .url("/products/1")
+                .alertRead(false)
+                .endDatetime(LocalDateTime.now())
+                .build();
+        Alert save = alertRepository.save(alert);
+        Long AlertId = save.getId();
+
+        // when
+        alertService.alertCheck(AlertId);
+
+        // then
+    }
+
+    @Test
+    @DisplayName("fail : 알람목록 확인 - 없는 알람 아이디")
+    void alertCheckNullId(){
+        // given
+        Alert alert = Alert.builder()
+                .id(1L)
+                .memberId(1L)
+                .title("제목")
+                .contents("내용")
+                .code(AlertCode.AC0007)
+                .url("/products/1")
+                .alertRead(false)
+                .endDatetime(LocalDateTime.now())
+                .build();
+        alertRepository.save(alert);
+        Long AlertId = Long.MAX_VALUE;
+
+        // when
+        assertThrows(DomainNotFoundException.class, () -> alertService.alertCheck(AlertId));
     }
 }


### PR DESCRIPTION
## 💁‍♂️ PR 내용
알람 확인

## 🙏 작업
알람의 확인 상태를 false -> ture 로 변경해 준다.

test case 
controller : 토큰이 없을 때
service : 없는 알람 아이디 일때

## 🙈 PR 참고 사항
PR은 추후 클린 코드를 위하여 작성 하였습니다.
기능 확인은 하였으니 PUSH 하도록 하겠습니다.